### PR TITLE
DEV-7413 support absolute paths for config and swagger files

### DIFF
--- a/all/generate/build.sh
+++ b/all/generate/build.sh
@@ -124,7 +124,8 @@ cp .openapi-generator-ignore output/.openapi-generator-ignore
 mv $sdk_name.json output/$sdk_name.json
 
 # build the sdk
-docker-compose build && docker-compose run lusid-sdk-gen ./generate/generate.sh ./generate ./generate/output $swagger_file $config_file 
+docker-compose build && docker-compose run lusid-sdk-gen ./generate/generate.sh ./generate ./generate/output \
+    $(basename $swagger_file) $(basename $config_file)
 docker-compose rm -f
 
 rm -f docker-compose.yml


### PR DESCRIPTION
The generator scripts should support absolute paths being provided for swagger and config files.   The current implementation only supports files in the current working directory.

This change allows files to specified with full paths.