### PR TITLE
SE-241 Restore C# templates for headers

### DIFF
--- a/csharp/generate/generate.sh
+++ b/csharp/generate/generate.sh
@@ -58,6 +58,7 @@ java -jar openapi-generator-cli.jar generate \
     -g csharp \
     -o $sdk_output_folder \
     -c $config_file \
+    -t $gen_root/templates \
 	--type-mappings dateorcutlabel=DateTimeOrCutLabel \
   --type-mappings double=decimal
 


### PR DESCRIPTION
Restore C# templates (lost in a previous revert) to log headers