### PR TITLE
SE-317: fix python generator bug

### DIFF
--- a/python/generate/templates/rest.mustache
+++ b/python/generate/templates/rest.mustache
@@ -208,10 +208,6 @@ class RESTClientObject(object):
         if _preload_content:
             r = RESTResponse(r)
 
-            # In the python 3, the response.data is bytes.
-            # we need to decode it to string.
-            if six.PY3:
-                r.data = r.data.decode('utf8')
 
             # log response body
             logger.debug("response body: %s", r.data)


### PR DESCRIPTION
PR to remove two lines of code from the python rest template which converts all rest responses into strings. 

This was creating a bug where the drive-sdk download_file api would not work as the file was being returned as a string.

