### PR TITLE
SE-874: Fix cryptography version to unblock python publish step

### DIFF
--- a/python/publish/Dockerfile
+++ b/python/publish/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.0
 
-RUN pip install twine
+RUN pip install cryptography==3.3.1 twine
 
 RUN mkdir -p /usr/src/
 RUN mkdir -p /usr/work/


### PR DESCRIPTION
The python publish job in concourse was installing a newer version of the cryptography module which included breaking changes. This commit fixes the version to revert the breaking change. 

