### PR TITLE
SE-1396: Updated the links to point to valid locations

### DIFF
--- a/all/generate/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/all/generate/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,10 +9,10 @@ assignees: ''
 
 ## Bug Report Checklist
 
-- [ ] I have checked the existing [documentation](../../../../wiki) for this SDK
+- [ ] I have checked the existing [documentation](../wiki) for this SDK
 - [ ] I have searched for any related issues/PRs
-- [ ] I have read the [LUISD contribution guidelines](../../docs/CONTRIBUTING.md)
-- [ ] I have read the [LUSID Code of Conduct](../../docs/CODE_OF_CONDUCT.md)
+- [ ] I have read the [LUISD contribution guidelines](../blob/master/docs/CONTRIBUTING.md)
+- [ ] I have read the [LUSID Code of Conduct](../blob/master/docs/CODE_OF_CONDUCT.md)
 
 **SDK version**
 The version of the SDK that has the bug. 

--- a/all/generate/.github/pull_request_template.md
+++ b/all/generate/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Pull Request Checklist
 
-- [ ] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
+- [ ] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
 - [ ] Tests pass
 - [ ] Raised the PR against the `develop` branch
 


### PR DESCRIPTION
The links to the wiki and Readme docs in the PR and Issue Template files dont actually work when clicked from an actual PR or Issue. Try it by clicking the Contribution link in any SDK project checklist. It wont take you to a valid page.

This PR fixes the links so they will work correctly when clicked from PRs and Issues at the small cost of breaking the links when clicking them as checked out source files or from the GitHub file viewer. I believe these use cases are less important and the trade-off makes sense.