### PR TITLE
Add way to handle a file provided as an array of bytes

### DIFF
--- a/csharp/generate/default_templates/ApiClient.mustache
+++ b/csharp/generate/default_templates/ApiClient.mustache
@@ -1,0 +1,874 @@
+{{>partial_header}}
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters;
+using System.Text;
+using System.Threading;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+{{^netStandard}}
+using System.Web;
+{{/netStandard}}
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
+using RestSharp;
+using RestSharp.Deserializers;
+using RestSharpMethod = RestSharp.Method;
+{{#useWebRequest}}
+using System.Net.Http;
+{{/useWebRequest}}
+{{#supportsRetry}}
+using Polly;
+{{/supportsRetry}}
+
+namespace {{packageName}}.Client
+{
+    /// <summary>
+    /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
+    /// </summary>
+    internal class CustomJsonCodec : RestSharp.Serializers.ISerializer, RestSharp.Deserializers.IDeserializer
+    {
+        private readonly IReadableConfiguration _configuration;
+        private static readonly string _contentType = "application/json";
+        private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
+        {
+            // OpenAPI generated types generally hide default constructors.
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    OverrideSpecifiedNames = false
+                }
+            }
+        };
+
+        public CustomJsonCodec(IReadableConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public CustomJsonCodec(JsonSerializerSettings serializerSettings, IReadableConfiguration configuration)
+        {
+            _serializerSettings = serializerSettings;
+            _configuration = configuration;
+        }
+
+        /// <summary>
+        /// Serialize the object into a JSON string.
+        /// </summary>
+        /// <param name="obj">Object to be serialized.</param>
+        /// <returns>A JSON string.</returns>
+        public string Serialize(object obj)
+        {
+            if (obj != null && obj is {{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema)
+            {
+                // the object to be serialized is an oneOf/anyOf schema
+                return (({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema)obj).ToJson();
+            }
+            else
+            {
+                return JsonConvert.SerializeObject(obj, _serializerSettings);
+            }
+        }
+
+        public T Deserialize<T>(IRestResponse response)
+        {
+            var result = (T)Deserialize(response, typeof(T));
+            return result;
+        }
+
+        /// <summary>
+        /// Deserialize the JSON string into a proper object.
+        /// </summary>
+        /// <param name="response">The HTTP response.</param>
+        /// <param name="type">Object type.</param>
+        /// <returns>Object representation of the JSON string.</returns>
+        internal object Deserialize(IRestResponse response, Type type)
+        {
+            if (type == typeof(byte[])) // return byte array
+            {
+                return response.RawBytes;
+            }
+
+            // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
+            if (type == typeof(Stream))
+            {
+                var bytes = response.RawBytes;
+                if (response.Headers != null)
+                {
+                    var filePath = string.IsNullOrEmpty(_configuration.TempFolderPath)
+                        ? Path.GetTempPath()
+                        : _configuration.TempFolderPath;
+                    var regex = new Regex(@"Content-Disposition=.*filename=['""]?([^'""\s]+)['""]?$");
+                    foreach (var header in response.Headers)
+                    {
+                        var match = regex.Match(header.ToString());
+                        if (match.Success)
+                        {
+                            string fileName = filePath + ClientUtils.SanitizeFilename(match.Groups[1].Value.Replace("\"", "").Replace("'", ""));
+                            File.WriteAllBytes(fileName, bytes);
+                            return new FileStream(fileName, FileMode.Open);
+                        }
+                    }
+                }
+                var stream = new MemoryStream(bytes);
+                return stream;
+            }
+
+            if (type.Name.StartsWith("System.Nullable`1[[System.DateTime")) // return a datetime object
+            {
+                return DateTime.Parse(response.Content, null, System.Globalization.DateTimeStyles.RoundtripKind);
+            }
+
+            if (type == typeof(string) || type.Name.StartsWith("System.Nullable")) // return primitive type
+            {
+                return Convert.ChangeType(response.Content, type);
+            }
+
+            // at this point, it must be a model (json)
+            try
+            {
+                return JsonConvert.DeserializeObject(response.Content, type, _serializerSettings);
+            }
+            catch (Exception e)
+            {
+                throw new ApiException(500, e.Message);
+            }
+        }
+
+        public string RootElement { get; set; }
+        public string Namespace { get; set; }
+        public string DateFormat { get; set; }
+
+        public string ContentType
+        {
+            get { return _contentType; }
+            set { throw new InvalidOperationException("Not allowed to set content type."); }
+        }
+    }
+    {{! NOTE: Any changes related to RestSharp should be done in this class. All other client classes are for extensibility by consumers.}}
+    /// <summary>
+    /// Provides a default implementation of an Api client (both synchronous and asynchronous implementations),
+    /// encapsulating general REST accessor use cases.
+    /// </summary>
+    {{>visibility}} partial class ApiClient : ISynchronousClient{{#supportsAsync}}, IAsynchronousClient{{/supportsAsync}}
+    {
+        private readonly string _baseUrl;
+
+        /// <summary>
+        /// Specifies the settings on a <see cref="JsonSerializer" /> object.
+        /// These settings can be adjusted to accommodate custom serialization rules.
+        /// </summary>
+        public JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings
+        {
+            // OpenAPI generated types generally hide default constructors.
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    OverrideSpecifiedNames = false
+                }
+            }
+        };
+
+        /// <summary>
+        /// Allows for extending request processing for <see cref="ApiClient"/> generated code.
+        /// </summary>
+        /// <param name="request">The RestSharp request object</param>
+        partial void InterceptRequest(IRestRequest request);
+
+        /// <summary>
+        /// Allows for extending response processing for <see cref="ApiClient"/> generated code.
+        /// </summary>
+        /// <param name="request">The RestSharp request object</param>
+        /// <param name="response">The RestSharp response object</param>
+        partial void InterceptResponse(IRestRequest request, IRestResponse response);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiClient" />, defaulting to the global configurations' base url.
+        /// </summary>
+        public ApiClient()
+        {
+            _baseUrl = {{packageName}}.Client.GlobalConfiguration.Instance.BasePath;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiClient" />
+        /// </summary>
+        /// <param name="basePath">The target service's base path in URL format.</param>
+        /// <exception cref="ArgumentException"></exception>
+        public ApiClient(string basePath)
+        {
+            if (string.IsNullOrEmpty(basePath))
+                throw new ArgumentException("basePath cannot be empty");
+
+            _baseUrl = basePath;
+        }
+
+        /// <summary>
+        /// Constructs the RestSharp version of an http method
+        /// </summary>
+        /// <param name="method">Swagger Client Custom HttpMethod</param>
+        /// <returns>RestSharp's HttpMethod instance.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private RestSharpMethod Method(HttpMethod method)
+        {
+            RestSharpMethod other;
+            switch (method)
+            {
+                case HttpMethod.Get:
+                    other = RestSharpMethod.GET;
+                    break;
+                case HttpMethod.Post:
+                    other = RestSharpMethod.POST;
+                    break;
+                case HttpMethod.Put:
+                    other = RestSharpMethod.PUT;
+                    break;
+                case HttpMethod.Delete:
+                    other = RestSharpMethod.DELETE;
+                    break;
+                case HttpMethod.Head:
+                    other = RestSharpMethod.HEAD;
+                    break;
+                case HttpMethod.Options:
+                    other = RestSharpMethod.OPTIONS;
+                    break;
+                case HttpMethod.Patch:
+                    other = RestSharpMethod.PATCH;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("method", method, null);
+            }
+
+            return other;
+        }
+
+        /// <summary>
+        /// Provides all logic for constructing a new RestSharp <see cref="RestRequest"/>.
+        /// At this point, all information for querying the service is known. Here, it is simply
+        /// mapped into the RestSharp request.
+        /// </summary>
+        /// <param name="method">The http verb.</param>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>[private] A new RestRequest instance.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        private RestRequest NewRequest(
+            HttpMethod method,
+            string path,
+            RequestOptions options,
+            IReadableConfiguration configuration)
+        {
+            if (path == null) throw new ArgumentNullException("path");
+            if (options == null) throw new ArgumentNullException("options");
+            if (configuration == null) throw new ArgumentNullException("configuration");
+
+            RestRequest request = new RestRequest(Method(method))
+            {
+                Resource = path,
+                JsonSerializer = new CustomJsonCodec(SerializerSettings, configuration)
+            };
+
+            if (options.PathParameters != null)
+            {
+                foreach (var pathParam in options.PathParameters)
+                {
+                    request.AddParameter(pathParam.Key, pathParam.Value, ParameterType.UrlSegment);
+                }
+            }
+
+            if (options.QueryParameters != null)
+            {
+                foreach (var queryParam in options.QueryParameters)
+                {
+                    foreach (var value in queryParam.Value)
+                    {
+                        request.AddQueryParameter(queryParam.Key, value);
+                    }
+                }
+            }
+
+            if (configuration.DefaultHeaders != null)
+            {
+                foreach (var headerParam in configuration.DefaultHeaders)
+                {
+                    request.AddHeader(headerParam.Key, headerParam.Value);
+                }
+            }
+
+            if (options.HeaderParameters != null)
+            {
+                foreach (var headerParam in options.HeaderParameters)
+                {
+                    foreach (var value in headerParam.Value)
+                    {
+                        request.AddHeader(headerParam.Key, value);
+                    }
+                }
+            }
+
+            if (options.FormParameters != null)
+            {
+                foreach (var formParam in options.FormParameters)
+                {
+                    request.AddParameter(formParam.Key, formParam.Value);
+                }
+            }
+
+            if (options.Data != null)
+            {
+                if (options.Data is Stream stream)
+                {
+                    var contentType = "application/octet-stream";
+                    if (options.HeaderParameters != null)
+                    {
+                        var contentTypes = options.HeaderParameters["Content-Type"];
+                        contentType = contentTypes[0];
+                    }
+
+                    var bytes = ClientUtils.ReadAsBytes(stream);
+                    request.AddParameter(contentType, bytes, ParameterType.RequestBody);
+                }
+                else
+                {
+                    if (options.HeaderParameters != null)
+                    {
+                        var contentTypes = options.HeaderParameters["Content-Type"];
+                        if (contentTypes == null || contentTypes.Any(header => header.Contains("application/json")))
+                        {
+                            request.RequestFormat = DataFormat.Json;
+                        }
+                        else
+                        {
+                            // TODO: Generated client user should add additional handlers. RestSharp only supports XML and JSON, with XML as default.
+                        }
+                    }
+                    else
+                    {
+                        // Here, we'll assume JSON APIs are more common. XML can be forced by adding produces/consumes to openapi spec explicitly.
+                        request.RequestFormat = DataFormat.Json;
+                    }
+
+                    request.AddJsonBody(options.Data);
+                }
+            }
+
+            if (options.FileParameters != null)
+            {
+                foreach (var fileParam in options.FileParameters)
+                {
+                    var bytes = ClientUtils.ReadAsBytes(fileParam.Value);
+                    var fileStream = fileParam.Value as FileStream;
+                    if (fileStream != null)
+                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
+                    else
+                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                }
+            }
+
+            if (options.Cookies != null && options.Cookies.Count > 0)
+            {
+                foreach (var cookie in options.Cookies)
+                {
+                    request.AddCookie(cookie.Name, cookie.Value);
+                }
+            }
+
+            return request;
+        }
+
+        private ApiResponse<T> ToApiResponse<T>(IRestResponse<T> response)
+        {
+            T result = response.Data;
+            string rawContent = response.Content;
+
+            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result, rawContent)
+            {
+                ErrorText = response.ErrorMessage,
+                Cookies = new List<Cookie>()
+            };
+
+            if (response.Headers != null)
+            {
+                foreach (var responseHeader in response.Headers)
+                {
+                    transformed.Headers.Add(responseHeader.Name, ClientUtils.ParameterToString(responseHeader.Value));
+                }
+            }
+
+            if (response.Cookies != null)
+            {
+                foreach (var responseCookies in response.Cookies)
+                {
+                    transformed.Cookies.Add(
+                        new Cookie(
+                            responseCookies.Name,
+                            responseCookies.Value,
+                            responseCookies.Path,
+                            responseCookies.Domain)
+                        );
+                }
+            }
+
+            return transformed;
+        }
+
+        private ApiResponse<T> Exec<T>(RestRequest req, IReadableConfiguration configuration)
+        {
+            RestClient client = new RestClient(_baseUrl);
+
+            client.ClearHandlers();
+            var existingDeserializer = req.JsonSerializer as IDeserializer;
+            if (existingDeserializer != null)
+            {
+                client.AddHandler("application/json", () => existingDeserializer);
+                client.AddHandler("text/json", () => existingDeserializer);
+                client.AddHandler("text/x-json", () => existingDeserializer);
+                client.AddHandler("text/javascript", () => existingDeserializer);
+                client.AddHandler("*+json", () => existingDeserializer);
+            }
+            else
+            {
+                var customDeserializer = new CustomJsonCodec(SerializerSettings, configuration);
+                client.AddHandler("application/json", () => customDeserializer);
+                client.AddHandler("text/json", () => customDeserializer);
+                client.AddHandler("text/x-json", () => customDeserializer);
+                client.AddHandler("text/javascript", () => customDeserializer);
+                client.AddHandler("*+json", () => customDeserializer);
+            }
+
+            var xmlDeserializer = new XmlDeserializer();
+            client.AddHandler("application/xml", () => xmlDeserializer);
+            client.AddHandler("text/xml", () => xmlDeserializer);
+            client.AddHandler("*+xml", () => xmlDeserializer);
+            client.AddHandler("*", () => xmlDeserializer);
+
+            client.Timeout = configuration.Timeout;
+
+            if (configuration.Proxy != null)
+            {
+                client.Proxy = configuration.Proxy;
+            }
+
+            if (configuration.UserAgent != null)
+            {
+                client.UserAgent = configuration.UserAgent;
+            }
+
+            if (configuration.ClientCertificates != null)
+            {
+                client.ClientCertificates = configuration.ClientCertificates;
+            }
+
+            InterceptRequest(req);
+
+            IRestResponse<T> response;
+            if (RetryConfiguration.RetryPolicy != null)
+            {
+                var policy = RetryConfiguration.RetryPolicy;
+                var policyResult = policy.ExecuteAndCapture(() => client.Execute(req));
+                response = (policyResult.Outcome == OutcomeType.Successful) ? client.Deserialize<T>(policyResult.Result) : new RestResponse<T>
+                {
+                    Request = req,
+                    ErrorException = policyResult.FinalException
+                };
+            }
+            else
+            {
+                response = client.Execute<T>(req);
+            }
+
+            // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
+            if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+            {
+                try
+                {
+                    response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+                }
+                catch (Exception ex)
+                {
+                    throw ex.InnerException != null ? ex.InnerException : ex;
+                }
+            }
+            else if (typeof(T).Name == "Stream") // for binary response
+            {
+                response.Data = (T)(object)new MemoryStream(response.RawBytes);
+            }
+
+            InterceptResponse(req, response);
+
+            var result = ToApiResponse(response);
+            if (response.ErrorMessage != null)
+            {
+                result.ErrorText = response.ErrorMessage;
+            }
+
+            if (response.Cookies != null && response.Cookies.Count > 0)
+            {
+                if (result.Cookies == null) result.Cookies = new List<Cookie>();
+                foreach (var restResponseCookie in response.Cookies)
+                {
+                    var cookie = new Cookie(
+                        restResponseCookie.Name,
+                        restResponseCookie.Value,
+                        restResponseCookie.Path,
+                        restResponseCookie.Domain
+                    )
+                    {
+                        Comment = restResponseCookie.Comment,
+                        CommentUri = restResponseCookie.CommentUri,
+                        Discard = restResponseCookie.Discard,
+                        Expired = restResponseCookie.Expired,
+                        Expires = restResponseCookie.Expires,
+                        HttpOnly = restResponseCookie.HttpOnly,
+                        Port = restResponseCookie.Port,
+                        Secure = restResponseCookie.Secure,
+                        Version = restResponseCookie.Version
+                    };
+
+                    result.Cookies.Add(cookie);
+                }
+            }
+            return result;
+        }
+
+        {{#supportsAsync}}
+        private async Task<ApiResponse<T>> ExecAsync<T>(RestRequest req, IReadableConfiguration configuration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            RestClient client = new RestClient(_baseUrl);
+
+            client.ClearHandlers();
+            var existingDeserializer = req.JsonSerializer as IDeserializer;
+            if (existingDeserializer != null)
+            {
+                client.AddHandler("application/json", () => existingDeserializer);
+                client.AddHandler("text/json", () => existingDeserializer);
+                client.AddHandler("text/x-json", () => existingDeserializer);
+                client.AddHandler("text/javascript", () => existingDeserializer);
+                client.AddHandler("*+json", () => existingDeserializer);
+            }
+            else
+            {
+                var customDeserializer = new CustomJsonCodec(SerializerSettings, configuration);
+                client.AddHandler("application/json", () => customDeserializer);
+                client.AddHandler("text/json", () => customDeserializer);
+                client.AddHandler("text/x-json", () => customDeserializer);
+                client.AddHandler("text/javascript", () => customDeserializer);
+                client.AddHandler("*+json", () => customDeserializer);
+            }
+
+            var xmlDeserializer = new XmlDeserializer();
+            client.AddHandler("application/xml", () => xmlDeserializer);
+            client.AddHandler("text/xml", () => xmlDeserializer);
+            client.AddHandler("*+xml", () => xmlDeserializer);
+            client.AddHandler("*", () => xmlDeserializer);
+
+            client.Timeout = configuration.Timeout;
+
+            if (configuration.Proxy != null)
+            {
+                client.Proxy = configuration.Proxy;
+            }
+
+            if (configuration.UserAgent != null)
+            {
+                client.UserAgent = configuration.UserAgent;
+            }
+
+            if (configuration.ClientCertificates != null)
+            {
+                client.ClientCertificates = configuration.ClientCertificates;
+            }
+
+            InterceptRequest(req);
+
+            IRestResponse<T> response;
+        {{#supportsRetry}}
+            if (RetryConfiguration.AsyncRetryPolicy != null)
+            {
+                var policy = RetryConfiguration.AsyncRetryPolicy;
+                var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(req, ct), cancellationToken).ConfigureAwait(false);
+                response = (policyResult.Outcome == OutcomeType.Successful) ? client.Deserialize<T>(policyResult.Result) : new RestResponse<T>
+                {
+                    Request = req,
+                    ErrorException = policyResult.FinalException
+                };
+            }
+            else
+            {
+        {{/supportsRetry}}
+                response = await client.ExecuteAsync<T>(req, cancellationToken).ConfigureAwait(false);
+        {{#supportsRetry}}
+            }
+        {{/supportsRetry}}
+
+            // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
+            if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+            {
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+            }
+            else if (typeof(T).Name == "Stream") // for binary response
+            {
+                response.Data = (T)(object)new MemoryStream(response.RawBytes);
+            }
+
+            InterceptResponse(req, response);
+
+            var result = ToApiResponse(response);
+            if (response.ErrorMessage != null)
+            {
+                result.ErrorText = response.ErrorMessage;
+            }
+
+            if (response.Cookies != null && response.Cookies.Count > 0)
+            {
+                if (result.Cookies == null) result.Cookies = new List<Cookie>();
+                foreach (var restResponseCookie in response.Cookies)
+                {
+                    var cookie = new Cookie(
+                        restResponseCookie.Name,
+                        restResponseCookie.Value,
+                        restResponseCookie.Path,
+                        restResponseCookie.Domain
+                    )
+                    {
+                        Comment = restResponseCookie.Comment,
+                        CommentUri = restResponseCookie.CommentUri,
+                        Discard = restResponseCookie.Discard,
+                        Expired = restResponseCookie.Expired,
+                        Expires = restResponseCookie.Expires,
+                        HttpOnly = restResponseCookie.HttpOnly,
+                        Port = restResponseCookie.Port,
+                        Secure = restResponseCookie.Secure,
+                        Version = restResponseCookie.Version
+                    };
+
+                    result.Cookies.Add(cookie);
+                }
+            }
+            return result;
+        }
+
+        #region IAsynchronousClient
+        /// <summary>
+        /// Make a HTTP GET request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> GetAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Get, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP POST request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> PostAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Post, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP PUT request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> PutAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Put, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP DELETE request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> DeleteAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Delete, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP HEAD request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> HeadAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Head, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP OPTION request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> OptionsAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Options, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP PATCH request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> PatchAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Patch, path, options, config), config, cancellationToken);
+        }
+        #endregion IAsynchronousClient
+        {{/supportsAsync}}
+
+        #region ISynchronousClient
+        /// <summary>
+        /// Make a HTTP GET request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Get<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Get, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP POST request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Post<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Post, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP PUT request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Put<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Put, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP DELETE request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Delete<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Delete, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP HEAD request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Head<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Head, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP OPTION request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Options<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Options, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP PATCH request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Patch<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Patch, path, options, config), config);
+        }
+        #endregion ISynchronousClient
+    }
+}

--- a/csharp/generate/templates/ApiClient.mustache
+++ b/csharp/generate/templates/ApiClient.mustache
@@ -333,24 +333,22 @@ namespace {{packageName}}.Client
             {
                 if (options.Data is Stream stream)
                 {
-                    var contentType = "application/octet-stream";
-                    if (options.HeaderParameters != null)
-                    {
-                        var contentTypes = options.HeaderParameters["Content-Type"];
-                        contentType = contentTypes[0];
-                    }
+                    var defaultContentType = "application/octet-stream";
+                    var contentType = 
+                        (options.HeaderParameters == null) ? 
+                        defaultContentType : 
+                        options.HeaderParameters["Content-Type"][0];
 
                     var bytes = ClientUtils.ReadAsBytes(stream);
                     request.AddParameter(contentType, bytes, ParameterType.RequestBody);
                 }
                 else if (options.Data is byte[])
                 {
-                    var contentType = "application/octet-stream";
-                    if (options.HeaderParameters != null)
-                    {
-                        var contentTypes = options.HeaderParameters["Content-Type"];
-                        contentType = contentTypes[0];
-                    }
+                    var defaultContentType = "application/octet-stream";
+                    var contentType = 
+                        (options.HeaderParameters == null) ? 
+                        defaultContentType : 
+                        options.HeaderParameters["Content-Type"][0];
 
                     var bytes = options.Data;
                     request.AddParameter(contentType, bytes, ParameterType.RequestBody);

--- a/csharp/generate/templates/ApiClient.mustache
+++ b/csharp/generate/templates/ApiClient.mustache
@@ -1,0 +1,886 @@
+{{>partial_header}}
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters;
+using System.Text;
+using System.Threading;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+{{^netStandard}}
+using System.Web;
+{{/netStandard}}
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
+using RestSharp;
+using RestSharp.Deserializers;
+using RestSharpMethod = RestSharp.Method;
+{{#useWebRequest}}
+using System.Net.Http;
+{{/useWebRequest}}
+{{#supportsRetry}}
+using Polly;
+{{/supportsRetry}}
+
+namespace {{packageName}}.Client
+{
+    /// <summary>
+    /// Allows RestSharp to Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
+    /// </summary>
+    internal class CustomJsonCodec : RestSharp.Serializers.ISerializer, RestSharp.Deserializers.IDeserializer
+    {
+        private readonly IReadableConfiguration _configuration;
+        private static readonly string _contentType = "application/json";
+        private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
+        {
+            // OpenAPI generated types generally hide default constructors.
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    OverrideSpecifiedNames = false
+                }
+            }
+        };
+
+        public CustomJsonCodec(IReadableConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public CustomJsonCodec(JsonSerializerSettings serializerSettings, IReadableConfiguration configuration)
+        {
+            _serializerSettings = serializerSettings;
+            _configuration = configuration;
+        }
+
+        /// <summary>
+        /// Serialize the object into a JSON string.
+        /// </summary>
+        /// <param name="obj">Object to be serialized.</param>
+        /// <returns>A JSON string.</returns>
+        public string Serialize(object obj)
+        {
+            if (obj != null && obj is {{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema)
+            {
+                // the object to be serialized is an oneOf/anyOf schema
+                return (({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema)obj).ToJson();
+            }
+            else
+            {
+                return JsonConvert.SerializeObject(obj, _serializerSettings);
+            }
+        }
+
+        public T Deserialize<T>(IRestResponse response)
+        {
+            var result = (T)Deserialize(response, typeof(T));
+            return result;
+        }
+
+        /// <summary>
+        /// Deserialize the JSON string into a proper object.
+        /// </summary>
+        /// <param name="response">The HTTP response.</param>
+        /// <param name="type">Object type.</param>
+        /// <returns>Object representation of the JSON string.</returns>
+        internal object Deserialize(IRestResponse response, Type type)
+        {
+            if (type == typeof(byte[])) // return byte array
+            {
+                return response.RawBytes;
+            }
+
+            // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
+            if (type == typeof(Stream))
+            {
+                var bytes = response.RawBytes;
+                if (response.Headers != null)
+                {
+                    var filePath = string.IsNullOrEmpty(_configuration.TempFolderPath)
+                        ? Path.GetTempPath()
+                        : _configuration.TempFolderPath;
+                    var regex = new Regex(@"Content-Disposition=.*filename=['""]?([^'""\s]+)['""]?$");
+                    foreach (var header in response.Headers)
+                    {
+                        var match = regex.Match(header.ToString());
+                        if (match.Success)
+                        {
+                            string fileName = filePath + ClientUtils.SanitizeFilename(match.Groups[1].Value.Replace("\"", "").Replace("'", ""));
+                            File.WriteAllBytes(fileName, bytes);
+                            return new FileStream(fileName, FileMode.Open);
+                        }
+                    }
+                }
+                var stream = new MemoryStream(bytes);
+                return stream;
+            }
+
+            if (type.Name.StartsWith("System.Nullable`1[[System.DateTime")) // return a datetime object
+            {
+                return DateTime.Parse(response.Content, null, System.Globalization.DateTimeStyles.RoundtripKind);
+            }
+
+            if (type == typeof(string) || type.Name.StartsWith("System.Nullable")) // return primitive type
+            {
+                return Convert.ChangeType(response.Content, type);
+            }
+
+            // at this point, it must be a model (json)
+            try
+            {
+                return JsonConvert.DeserializeObject(response.Content, type, _serializerSettings);
+            }
+            catch (Exception e)
+            {
+                throw new ApiException(500, e.Message);
+            }
+        }
+
+        public string RootElement { get; set; }
+        public string Namespace { get; set; }
+        public string DateFormat { get; set; }
+
+        public string ContentType
+        {
+            get { return _contentType; }
+            set { throw new InvalidOperationException("Not allowed to set content type."); }
+        }
+    }
+    {{! NOTE: Any changes related to RestSharp should be done in this class. All other client classes are for extensibility by consumers.}}
+    /// <summary>
+    /// Provides a default implementation of an Api client (both synchronous and asynchronous implementations),
+    /// encapsulating general REST accessor use cases.
+    /// </summary>
+    {{>visibility}} partial class ApiClient : ISynchronousClient{{#supportsAsync}}, IAsynchronousClient{{/supportsAsync}}
+    {
+        private readonly string _baseUrl;
+
+        /// <summary>
+        /// Specifies the settings on a <see cref="JsonSerializer" /> object.
+        /// These settings can be adjusted to accommodate custom serialization rules.
+        /// </summary>
+        public JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings
+        {
+            // OpenAPI generated types generally hide default constructors.
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    OverrideSpecifiedNames = false
+                }
+            }
+        };
+
+        /// <summary>
+        /// Allows for extending request processing for <see cref="ApiClient"/> generated code.
+        /// </summary>
+        /// <param name="request">The RestSharp request object</param>
+        partial void InterceptRequest(IRestRequest request);
+
+        /// <summary>
+        /// Allows for extending response processing for <see cref="ApiClient"/> generated code.
+        /// </summary>
+        /// <param name="request">The RestSharp request object</param>
+        /// <param name="response">The RestSharp response object</param>
+        partial void InterceptResponse(IRestRequest request, IRestResponse response);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiClient" />, defaulting to the global configurations' base url.
+        /// </summary>
+        public ApiClient()
+        {
+            _baseUrl = {{packageName}}.Client.GlobalConfiguration.Instance.BasePath;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiClient" />
+        /// </summary>
+        /// <param name="basePath">The target service's base path in URL format.</param>
+        /// <exception cref="ArgumentException"></exception>
+        public ApiClient(string basePath)
+        {
+            if (string.IsNullOrEmpty(basePath))
+                throw new ArgumentException("basePath cannot be empty");
+
+            _baseUrl = basePath;
+        }
+
+        /// <summary>
+        /// Constructs the RestSharp version of an http method
+        /// </summary>
+        /// <param name="method">Swagger Client Custom HttpMethod</param>
+        /// <returns>RestSharp's HttpMethod instance.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private RestSharpMethod Method(HttpMethod method)
+        {
+            RestSharpMethod other;
+            switch (method)
+            {
+                case HttpMethod.Get:
+                    other = RestSharpMethod.GET;
+                    break;
+                case HttpMethod.Post:
+                    other = RestSharpMethod.POST;
+                    break;
+                case HttpMethod.Put:
+                    other = RestSharpMethod.PUT;
+                    break;
+                case HttpMethod.Delete:
+                    other = RestSharpMethod.DELETE;
+                    break;
+                case HttpMethod.Head:
+                    other = RestSharpMethod.HEAD;
+                    break;
+                case HttpMethod.Options:
+                    other = RestSharpMethod.OPTIONS;
+                    break;
+                case HttpMethod.Patch:
+                    other = RestSharpMethod.PATCH;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("method", method, null);
+            }
+
+            return other;
+        }
+
+        /// <summary>
+        /// Provides all logic for constructing a new RestSharp <see cref="RestRequest"/>.
+        /// At this point, all information for querying the service is known. Here, it is simply
+        /// mapped into the RestSharp request.
+        /// </summary>
+        /// <param name="method">The http verb.</param>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>[private] A new RestRequest instance.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        private RestRequest NewRequest(
+            HttpMethod method,
+            string path,
+            RequestOptions options,
+            IReadableConfiguration configuration)
+        {
+            if (path == null) throw new ArgumentNullException("path");
+            if (options == null) throw new ArgumentNullException("options");
+            if (configuration == null) throw new ArgumentNullException("configuration");
+
+            RestRequest request = new RestRequest(Method(method))
+            {
+                Resource = path,
+                JsonSerializer = new CustomJsonCodec(SerializerSettings, configuration)
+            };
+
+            if (options.PathParameters != null)
+            {
+                foreach (var pathParam in options.PathParameters)
+                {
+                    request.AddParameter(pathParam.Key, pathParam.Value, ParameterType.UrlSegment);
+                }
+            }
+
+            if (options.QueryParameters != null)
+            {
+                foreach (var queryParam in options.QueryParameters)
+                {
+                    foreach (var value in queryParam.Value)
+                    {
+                        request.AddQueryParameter(queryParam.Key, value);
+                    }
+                }
+            }
+
+            if (configuration.DefaultHeaders != null)
+            {
+                foreach (var headerParam in configuration.DefaultHeaders)
+                {
+                    request.AddHeader(headerParam.Key, headerParam.Value);
+                }
+            }
+
+            if (options.HeaderParameters != null)
+            {
+                foreach (var headerParam in options.HeaderParameters)
+                {
+                    foreach (var value in headerParam.Value)
+                    {
+                        request.AddHeader(headerParam.Key, value);
+                    }
+                }
+            }
+
+            if (options.FormParameters != null)
+            {
+                foreach (var formParam in options.FormParameters)
+                {
+                    request.AddParameter(formParam.Key, formParam.Value);
+                }
+            }
+
+            if (options.Data != null)
+            {
+                if (options.Data is Stream stream)
+                {
+                    var contentType = "application/octet-stream";
+                    if (options.HeaderParameters != null)
+                    {
+                        var contentTypes = options.HeaderParameters["Content-Type"];
+                        contentType = contentTypes[0];
+                    }
+
+                    var bytes = ClientUtils.ReadAsBytes(stream);
+                    request.AddParameter(contentType, bytes, ParameterType.RequestBody);
+                }
+                else if (options.Data is byte[])
+                {
+                    var contentType = "application/octet-stream";
+                    if (options.HeaderParameters != null)
+                    {
+                        var contentTypes = options.HeaderParameters["Content-Type"];
+                        contentType = contentTypes[0];
+                    }
+
+                    var bytes = options.Data;
+                    request.AddParameter(contentType, bytes, ParameterType.RequestBody);
+                }
+                else
+                {
+                    if (options.HeaderParameters != null)
+                    {
+                        var contentTypes = options.HeaderParameters["Content-Type"];
+                        if (contentTypes == null || contentTypes.Any(header => header.Contains("application/json")))
+                        {
+                            request.RequestFormat = DataFormat.Json;
+                        }
+                        else
+                        {
+                            // TODO: Generated client user should add additional handlers. RestSharp only supports XML and JSON, with XML as default.
+                        }
+                    }
+                    else
+                    {
+                        // Here, we'll assume JSON APIs are more common. XML can be forced by adding produces/consumes to openapi spec explicitly.
+                        request.RequestFormat = DataFormat.Json;
+                    }
+
+                    request.AddJsonBody(options.Data);
+                }
+            }
+
+            if (options.FileParameters != null)
+            {
+                foreach (var fileParam in options.FileParameters)
+                {
+                    var bytes = ClientUtils.ReadAsBytes(fileParam.Value);
+                    var fileStream = fileParam.Value as FileStream;
+                    if (fileStream != null)
+                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
+                    else
+                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                }
+            }
+
+            if (options.Cookies != null && options.Cookies.Count > 0)
+            {
+                foreach (var cookie in options.Cookies)
+                {
+                    request.AddCookie(cookie.Name, cookie.Value);
+                }
+            }
+
+            return request;
+        }
+
+        private ApiResponse<T> ToApiResponse<T>(IRestResponse<T> response)
+        {
+            T result = response.Data;
+            string rawContent = response.Content;
+
+            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result, rawContent)
+            {
+                ErrorText = response.ErrorMessage,
+                Cookies = new List<Cookie>()
+            };
+
+            if (response.Headers != null)
+            {
+                foreach (var responseHeader in response.Headers)
+                {
+                    transformed.Headers.Add(responseHeader.Name, ClientUtils.ParameterToString(responseHeader.Value));
+                }
+            }
+
+            if (response.Cookies != null)
+            {
+                foreach (var responseCookies in response.Cookies)
+                {
+                    transformed.Cookies.Add(
+                        new Cookie(
+                            responseCookies.Name,
+                            responseCookies.Value,
+                            responseCookies.Path,
+                            responseCookies.Domain)
+                        );
+                }
+            }
+
+            return transformed;
+        }
+
+        private ApiResponse<T> Exec<T>(RestRequest req, IReadableConfiguration configuration)
+        {
+            RestClient client = new RestClient(_baseUrl);
+
+            client.ClearHandlers();
+            var existingDeserializer = req.JsonSerializer as IDeserializer;
+            if (existingDeserializer != null)
+            {
+                client.AddHandler("application/json", () => existingDeserializer);
+                client.AddHandler("text/json", () => existingDeserializer);
+                client.AddHandler("text/x-json", () => existingDeserializer);
+                client.AddHandler("text/javascript", () => existingDeserializer);
+                client.AddHandler("*+json", () => existingDeserializer);
+            }
+            else
+            {
+                var customDeserializer = new CustomJsonCodec(SerializerSettings, configuration);
+                client.AddHandler("application/json", () => customDeserializer);
+                client.AddHandler("text/json", () => customDeserializer);
+                client.AddHandler("text/x-json", () => customDeserializer);
+                client.AddHandler("text/javascript", () => customDeserializer);
+                client.AddHandler("*+json", () => customDeserializer);
+            }
+
+            var xmlDeserializer = new XmlDeserializer();
+            client.AddHandler("application/xml", () => xmlDeserializer);
+            client.AddHandler("text/xml", () => xmlDeserializer);
+            client.AddHandler("*+xml", () => xmlDeserializer);
+            client.AddHandler("*", () => xmlDeserializer);
+
+            client.Timeout = configuration.Timeout;
+
+            if (configuration.Proxy != null)
+            {
+                client.Proxy = configuration.Proxy;
+            }
+
+            if (configuration.UserAgent != null)
+            {
+                client.UserAgent = configuration.UserAgent;
+            }
+
+            if (configuration.ClientCertificates != null)
+            {
+                client.ClientCertificates = configuration.ClientCertificates;
+            }
+
+            InterceptRequest(req);
+
+            IRestResponse<T> response;
+            if (RetryConfiguration.RetryPolicy != null)
+            {
+                var policy = RetryConfiguration.RetryPolicy;
+                var policyResult = policy.ExecuteAndCapture(() => client.Execute(req));
+                response = (policyResult.Outcome == OutcomeType.Successful) ? client.Deserialize<T>(policyResult.Result) : new RestResponse<T>
+                {
+                    Request = req,
+                    ErrorException = policyResult.FinalException
+                };
+            }
+            else
+            {
+                response = client.Execute<T>(req);
+            }
+
+            // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
+            if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+            {
+                try
+                {
+                    response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+                }
+                catch (Exception ex)
+                {
+                    throw ex.InnerException != null ? ex.InnerException : ex;
+                }
+            }
+            else if (typeof(T).Name == "Stream") // for binary response
+            {
+                response.Data = (T)(object)new MemoryStream(response.RawBytes);
+            }
+
+            InterceptResponse(req, response);
+
+            var result = ToApiResponse(response);
+            if (response.ErrorMessage != null)
+            {
+                result.ErrorText = response.ErrorMessage;
+            }
+
+            if (response.Cookies != null && response.Cookies.Count > 0)
+            {
+                if (result.Cookies == null) result.Cookies = new List<Cookie>();
+                foreach (var restResponseCookie in response.Cookies)
+                {
+                    var cookie = new Cookie(
+                        restResponseCookie.Name,
+                        restResponseCookie.Value,
+                        restResponseCookie.Path,
+                        restResponseCookie.Domain
+                    )
+                    {
+                        Comment = restResponseCookie.Comment,
+                        CommentUri = restResponseCookie.CommentUri,
+                        Discard = restResponseCookie.Discard,
+                        Expired = restResponseCookie.Expired,
+                        Expires = restResponseCookie.Expires,
+                        HttpOnly = restResponseCookie.HttpOnly,
+                        Port = restResponseCookie.Port,
+                        Secure = restResponseCookie.Secure,
+                        Version = restResponseCookie.Version
+                    };
+
+                    result.Cookies.Add(cookie);
+                }
+            }
+            return result;
+        }
+
+        {{#supportsAsync}}
+        private async Task<ApiResponse<T>> ExecAsync<T>(RestRequest req, IReadableConfiguration configuration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            RestClient client = new RestClient(_baseUrl);
+
+            client.ClearHandlers();
+            var existingDeserializer = req.JsonSerializer as IDeserializer;
+            if (existingDeserializer != null)
+            {
+                client.AddHandler("application/json", () => existingDeserializer);
+                client.AddHandler("text/json", () => existingDeserializer);
+                client.AddHandler("text/x-json", () => existingDeserializer);
+                client.AddHandler("text/javascript", () => existingDeserializer);
+                client.AddHandler("*+json", () => existingDeserializer);
+            }
+            else
+            {
+                var customDeserializer = new CustomJsonCodec(SerializerSettings, configuration);
+                client.AddHandler("application/json", () => customDeserializer);
+                client.AddHandler("text/json", () => customDeserializer);
+                client.AddHandler("text/x-json", () => customDeserializer);
+                client.AddHandler("text/javascript", () => customDeserializer);
+                client.AddHandler("*+json", () => customDeserializer);
+            }
+
+            var xmlDeserializer = new XmlDeserializer();
+            client.AddHandler("application/xml", () => xmlDeserializer);
+            client.AddHandler("text/xml", () => xmlDeserializer);
+            client.AddHandler("*+xml", () => xmlDeserializer);
+            client.AddHandler("*", () => xmlDeserializer);
+
+            client.Timeout = configuration.Timeout;
+
+            if (configuration.Proxy != null)
+            {
+                client.Proxy = configuration.Proxy;
+            }
+
+            if (configuration.UserAgent != null)
+            {
+                client.UserAgent = configuration.UserAgent;
+            }
+
+            if (configuration.ClientCertificates != null)
+            {
+                client.ClientCertificates = configuration.ClientCertificates;
+            }
+
+            InterceptRequest(req);
+
+            IRestResponse<T> response;
+        {{#supportsRetry}}
+            if (RetryConfiguration.AsyncRetryPolicy != null)
+            {
+                var policy = RetryConfiguration.AsyncRetryPolicy;
+                var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(req, ct), cancellationToken).ConfigureAwait(false);
+                response = (policyResult.Outcome == OutcomeType.Successful) ? client.Deserialize<T>(policyResult.Result) : new RestResponse<T>
+                {
+                    Request = req,
+                    ErrorException = policyResult.FinalException
+                };
+            }
+            else
+            {
+        {{/supportsRetry}}
+                response = await client.ExecuteAsync<T>(req, cancellationToken).ConfigureAwait(false);
+        {{#supportsRetry}}
+            }
+        {{/supportsRetry}}
+
+            // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
+            if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+            {
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+            }
+            else if (typeof(T).Name == "Stream") // for binary response
+            {
+                response.Data = (T)(object)new MemoryStream(response.RawBytes);
+            }
+
+            InterceptResponse(req, response);
+
+            var result = ToApiResponse(response);
+            if (response.ErrorMessage != null)
+            {
+                result.ErrorText = response.ErrorMessage;
+            }
+
+            if (response.Cookies != null && response.Cookies.Count > 0)
+            {
+                if (result.Cookies == null) result.Cookies = new List<Cookie>();
+                foreach (var restResponseCookie in response.Cookies)
+                {
+                    var cookie = new Cookie(
+                        restResponseCookie.Name,
+                        restResponseCookie.Value,
+                        restResponseCookie.Path,
+                        restResponseCookie.Domain
+                    )
+                    {
+                        Comment = restResponseCookie.Comment,
+                        CommentUri = restResponseCookie.CommentUri,
+                        Discard = restResponseCookie.Discard,
+                        Expired = restResponseCookie.Expired,
+                        Expires = restResponseCookie.Expires,
+                        HttpOnly = restResponseCookie.HttpOnly,
+                        Port = restResponseCookie.Port,
+                        Secure = restResponseCookie.Secure,
+                        Version = restResponseCookie.Version
+                    };
+
+                    result.Cookies.Add(cookie);
+                }
+            }
+            return result;
+        }
+
+        #region IAsynchronousClient
+        /// <summary>
+        /// Make a HTTP GET request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> GetAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Get, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP POST request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> PostAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Post, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP PUT request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> PutAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Put, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP DELETE request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> DeleteAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Delete, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP HEAD request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> HeadAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Head, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP OPTION request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> OptionsAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Options, path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP PATCH request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> PatchAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest(HttpMethod.Patch, path, options, config), config, cancellationToken);
+        }
+        #endregion IAsynchronousClient
+        {{/supportsAsync}}
+
+        #region ISynchronousClient
+        /// <summary>
+        /// Make a HTTP GET request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Get<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Get, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP POST request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Post<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Post, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP PUT request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Put<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Put, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP DELETE request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Delete<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Delete, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP HEAD request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Head<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Head, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP OPTION request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Options<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Options, path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP PATCH request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Patch<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest(HttpMethod.Patch, path, options, config), config);
+        }
+        #endregion ISynchronousClient
+    }
+}


### PR DESCRIPTION

<img width="874" alt="2021-09-07_15-55-58" src="https://user-images.githubusercontent.com/13220/132367501-38a3d930-c6b9-424e-9a25-c2c49d698ce3.png">


Without this change if we pass in `byte[]` (e.g. to upload a file) the SDK tries to serialise it as a JSON object.