### PR TITLE
SENG-54: change deserialization exception return values and pass results to ApiResponse

### DIFF
--- a/csharp/generate/default_templates/ApiResponse.mustache
+++ b/csharp/generate/default_templates/ApiResponse.mustache
@@ -1,0 +1,157 @@
+{{>partial_header}}
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace {{packageName}}.Client
+{
+    /// <summary>
+    /// Provides a non-generic contract for the ApiResponse wrapper.
+    /// </summary>
+    public interface IApiResponse
+    {
+        /// <summary>
+        /// The data type of <see cref="Content"/>
+        /// </summary>
+        Type ResponseType { get; }
+
+        /// <summary>
+        /// The content of this response
+        /// </summary>
+        Object Content { get; }
+
+        /// <summary>
+        /// Gets or sets the status code (HTTP status code)
+        /// </summary>
+        /// <value>The status code.</value>
+        HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets or sets the HTTP headers
+        /// </summary>
+        /// <value>HTTP headers</value>
+        Multimap<string, string> Headers { get; }
+
+        /// <summary>
+        /// Gets or sets any error text defined by the calling client.
+        /// </summary>
+        string ErrorText { get; set; }
+
+        /// <summary>
+        /// Gets or sets any cookies passed along on the response.
+        /// </summary>
+        List<Cookie> Cookies { get; set; }
+
+        /// <summary>
+        /// The raw content of this response
+        /// </summary>
+        string RawContent { get; }
+    }
+
+    /// <summary>
+    /// API Response
+    /// </summary>
+    public class ApiResponse<T> : IApiResponse
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the status code (HTTP status code)
+        /// </summary>
+        /// <value>The status code.</value>
+        public HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets or sets the HTTP headers
+        /// </summary>
+        /// <value>HTTP headers</value>
+        public Multimap<string, string> Headers { get; }
+
+        /// <summary>
+        /// Gets or sets the data (parsed HTTP body)
+        /// </summary>
+        /// <value>The data.</value>
+        public T Data { get; }
+
+        /// <summary>
+        /// Gets or sets any error text defined by the calling client.
+        /// </summary>
+        public string ErrorText { get; set; }
+
+        /// <summary>
+        /// Gets or sets any cookies passed along on the response.
+        /// </summary>
+        public List<Cookie> Cookies { get; set; }
+
+        /// <summary>
+        /// The content of this response
+        /// </summary>
+        public Type ResponseType
+        {
+            get { return typeof(T); }
+        }
+
+        /// <summary>
+        /// The data type of <see cref="Content"/>
+        /// </summary>
+        public object Content
+        {
+            get { return Data; }
+        }
+
+        /// <summary>
+        /// The raw content
+        /// </summary>
+        public string RawContent { get; }
+
+        #endregion Properties
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="headers">HTTP headers.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        /// <param name="rawContent">Raw content.</param>
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data, string rawContent)
+        {
+            StatusCode = statusCode;
+            Headers = headers;
+            Data = data;
+            RawContent = rawContent;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="headers">HTTP headers.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data) : this(statusCode, headers, data, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        /// <param name="rawContent">Raw content.</param>
+        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent) : this(statusCode, null, data, rawContent)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        public ApiResponse(HttpStatusCode statusCode, T data) : this(statusCode, data, null)
+        {
+        }
+
+        #endregion Constructors
+    }
+}

--- a/csharp/generate/templates/ApiClient.mustache
+++ b/csharp/generate/templates/ApiClient.mustache
@@ -135,15 +135,11 @@ namespace {{packageName}}.Client
                 return Convert.ChangeType(response.Content, type);
             }
 
-            // at this point, it must be a model (json)
-            try
-            {
-                return JsonConvert.DeserializeObject(response.Content, type, _serializerSettings);
-            }
-            catch (Exception e)
-            {
-                throw new ApiException(500, e.Message);
-            }
+            // If for some reason the response is a null, empty, or whitespace, the serialisation should fail.
+            if (string.IsNullOrWhiteSpace(response.Content))
+                throw new DeserializationException(response, new Exception($"API Response Content was invalid: '{response.Content}'"));
+
+            return JsonConvert.DeserializeObject(response.Content, type, _serializerSettings);
         }
 
         public string RootElement { get; set; }
@@ -409,6 +405,8 @@ namespace {{packageName}}.Client
             var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result, rawContent)
             {
                 ErrorText = response.ErrorMessage,
+                ResponseStatus = response.ResponseStatus,
+                InternalException = response.ErrorException,
                 Cookies = new List<Cookie>()
             };
 

--- a/csharp/generate/templates/ApiResponse.mustache
+++ b/csharp/generate/templates/ApiResponse.mustache
@@ -1,0 +1,178 @@
+{{>partial_header}}
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using RestSharp;
+
+namespace {{packageName}}.Client
+{
+    /// <summary>
+    /// Provides a non-generic contract for the ApiResponse wrapper.
+    /// </summary>
+    public interface IApiResponse
+    {
+        /// <summary>
+        /// The data type of <see cref="Content"/>
+        /// </summary>
+        Type ResponseType { get; }
+
+        /// <summary>
+        /// The content of this response
+        /// </summary>
+        Object Content { get; }
+
+        /// <summary>
+        /// Gets or sets the status code (HTTP status code)
+        /// </summary>
+        /// <value>The status code.</value>
+        HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets or sets the HTTP headers
+        /// </summary>
+        /// <value>HTTP headers</value>
+        Multimap<string, string> Headers { get; }
+
+        /// <summary>
+        /// Gets or sets any error text defined by the calling client.
+        /// </summary>
+        string ErrorText { get; set; }
+
+        /// <summary>
+        /// Gets or sets any cookies passed along on the response.
+        /// </summary>
+        List<Cookie> Cookies { get; set; }
+
+        /// <summary>
+        /// The raw content of this response
+        /// </summary>
+        string RawContent { get; }
+
+        /// <summary>
+        /// Status of the response. Indicates whether any internal errors have been thrown.
+        /// </summary>
+        ResponseStatus ResponseStatus { get; }
+
+        /// <summary>
+        /// Potential internal exception that might occur with the processing of the API call
+        /// </summary>
+        Exception InternalException { get; }
+    }
+
+    /// <summary>
+    /// API Response
+    /// </summary>
+    public class ApiResponse<T> : IApiResponse
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the status code (HTTP status code)
+        /// </summary>
+        /// <value>The status code.</value>
+        public HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets or sets the HTTP headers
+        /// </summary>
+        /// <value>HTTP headers</value>
+        public Multimap<string, string> Headers { get; }
+
+        /// <summary>
+        /// Gets or sets the data (parsed HTTP body)
+        /// </summary>
+        /// <value>The data.</value>
+        public T Data { get; }
+
+        /// <summary>
+        /// Gets or sets any error text defined by the calling client.
+        /// </summary>
+        public string ErrorText { get; set; }
+
+        /// <summary>
+        /// Gets or sets any cookies passed along on the response.
+        /// </summary>
+        public List<Cookie> Cookies { get; set; }
+
+        /// <summary>
+        /// The content of this response
+        /// </summary>
+        public Type ResponseType
+        {
+            get { return typeof(T); }
+        }
+
+        /// <summary>
+        /// The data type of <see cref="Content"/>
+        /// </summary>
+        public object Content
+        {
+            get { return Data; }
+        }
+
+        /// <summary>
+        /// The raw content
+        /// </summary>
+        public string RawContent { get; }
+
+        /// <summary>
+        /// Status of the response. Indicates whether any internal errors have been thrown.
+        /// </summary>
+        public ResponseStatus ResponseStatus { get; set; }
+
+        /// <summary>
+        /// Potential internal exception that might occur with the processing of the API call
+        /// </summary>
+        public Exception InternalException { get; set; }
+
+        #endregion Properties
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="headers">HTTP headers.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        /// <param name="rawContent">Raw content.</param>
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data, string rawContent)
+        {
+            StatusCode = statusCode;
+            Headers = headers;
+            Data = data;
+            RawContent = rawContent;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="headers">HTTP headers.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data) : this(statusCode, headers, data, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        /// <param name="rawContent">Raw content.</param>
+        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent) : this(statusCode, null, data, rawContent)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        public ApiResponse(HttpStatusCode statusCode, T data) : this(statusCode, data, null)
+        {
+        }
+
+        #endregion Constructors
+    }
+}


### PR DESCRIPTION
Changes

- Throwing a DeserializationError whenever an API response is a whitespace, an empty string, or a badly formed json instead of returning 'null' in these events.
- Adding ResponseStatus property to the ApiResponse object so that any internal SDK exceptions can be later handled in the ExceptionFactory
- Adding InternalException property to ApiResponse so that any exceptions thrown could later be handled in the ExceptionFactory. This exception will be accessible on any exception that occur during Deserialization.