### PR TITLE
CTECH-762: Allow the user to pass in any headers per request

### DIFF
--- a/python/generate/templates/api.mustache
+++ b/python/generate/templates/api.mustache
@@ -144,7 +144,8 @@ class {{classname}}(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_request_auth'
+                '_request_auth',
+                '_headers'
             ]
         )
 
@@ -221,7 +222,7 @@ class {{classname}}(object):
             collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isArray}}  # noqa: E501
 {{/queryParams}}
 
-        header_params = {}
+        header_params = dict(local_var_params.get('_headers', {}))
 {{#headerParams}}
         if '{{paramName}}' in local_var_params:
             header_params['{{baseName}}'] = local_var_params['{{paramName}}']{{#isArray}}  # noqa: E501
@@ -261,7 +262,7 @@ class {{classname}}(object):
 
         # Authentication setting
         auth_settings = [{{#authMethods}}'{{name}}'{{^-last}}, {{/-last}}{{/authMethods}}]  # noqa: E501
-        
+
         {{#returnType}}
         {{#responses}}
         {{#-first}}


### PR DESCRIPTION
This will not need to be maintained because the change is on the open-source. This is in place until we manage to update to the new version. 