### PR TITLE
CTECH-1344: Enables PR Flow integration tests to be run with a /LGTM comment on the PR

### DIFF
--- a/all/generate/.github/workflows/build-and-test-branches.yaml
+++ b/all/generate/.github/workflows/build-and-test-branches.yaml
@@ -1,0 +1,62 @@
+# This job runs the project tests
+
+name: Build and test main branches
+
+# Trigger the workflow on push or pull request to master or develop
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  # This workflow contains a single job called "build"
+  build-and-test-develop-branch:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Set env variable BRANCH_FOR_SLACK for Slack message
+        run: |
+          echo "BRANCH_FOR_SLACK=${{ github.ref  }}" >> $GITHUB_ENV
+
+      - name: Run tests
+        env:
+          FBN_TOKEN_URL: ${{ secrets.DEVELOP_FBN_TOKEN_URL }}
+          FBN_USERNAME: ${{ secrets.DEVELOP_FBN_USERNAME }}
+          FBN_PASSWORD: ${{ secrets.DEVELOP_FBN_PASSWORD }}
+          FBN_CLIENT_ID: ${{ secrets.DEVELOP_FBN_CLIENT_ID }}
+          FBN_CLIENT_SECRET: ${{ secrets.DEVELOP_FBN_CLIENT_SECRET }}
+          FBN_LUSID_API_URL: ${{ secrets.DEVELOP_FBN_LUSID_API_URL }}
+          FBN_APP_NAME: ${{ secrets.DEVELOP_FBN_CLIENT_ID }}
+          FBN_ACCESS_TOKEN: ${{ secrets.DEVELOP_FBN_ACCESS_TOKEN }}
+          FBN_LUSID_ACCESS_TOKEN: ${{ secrets.DEVELOP_FBN_ACCESS_TOKEN }}
+        run: |
+          echo "env variables for DEVELOP have been set"
+          echo "Changing directory into sdk directory"
+          cd sdk          
+          echo "Running the tests..."
+          docker-compose up --abort-on-container-exit
+          echo "Tests COMPLETED"
+
+      - name: Slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,job,commit,repo,ref,author,took
+          custom_payload: |
+            {
+            username: 'github-actions-tests',
+            icon_emoji: ':octocat:',
+            attachments: [{
+              color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              text: `${process.env.AS_WORKFLOW} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.BRANCH_FOR_SLACK} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
+            }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure()

--- a/all/generate/.github/workflows/build-and-test.yaml
+++ b/all/generate/.github/workflows/build-and-test.yaml
@@ -5,70 +5,112 @@ name: Build and test
 # Trigger the workflow on push or pull request to master or develop
 
 on:
-  push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ master, develop ]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        type: string
+        required: true
+        description: The PR number.
 
 jobs:
   # This workflow contains a single job called "build"
-  build-and-test:
+  build-and-test-pr:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
+    environment: "PR-${{ github.event.inputs.pull_request }}"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      # the tip of the merge request is required for the check_run progress
+      - name: Checkout for SHA
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ github.event.inputs.pull_request }}/head"
 
-      - name: Set env variable BRANCH_FOR_SLACK for Slack message
-        run: |
-          if ${{ github.event_name == 'push' }} ; then
-            echo "BRANCH_FOR_SLACK=${{ github.ref  }}" >> $GITHUB_ENV
-          elif ${{ github.event_name == 'pull_request' }}; then
-            echo "BRANCH_FOR_SLACK=${{ github.base_ref  }}" >> $GITHUB_ENV
-          else
-            exit 1
-          fi
+      - name: Get SHA
+        id: vcs
+        run: echo "::set-output name=sha::$(git rev-parse HEAD)"
 
-      - name: Run tests on DEVELOP branch
-        if: ${{ github.base_ref == 'develop' || github.ref == 'refs/heads/develop' }}
-        env: 
-          FBN_TOKEN_URL: ${{ secrets.DEVELOP_FBN_TOKEN_URL }}
-          FBN_USERNAME: ${{ secrets.DEVELOP_FBN_USERNAME }}
-          FBN_PASSWORD: ${{ secrets.DEVELOP_FBN_PASSWORD }}
-          FBN_CLIENT_ID: ${{ secrets.DEVELOP_FBN_CLIENT_ID }}
-          FBN_CLIENT_SECRET: ${{ secrets.DEVELOP_FBN_CLIENT_SECRET }}
-          FBN_LUSID_API_URL: ${{ secrets.DEVELOP_FBN_LUSID_API_URL }}
-          FBN_APP_NAME: ${{ secrets.DEVELOP_FBN_CLIENT_ID }}
-          FBN_LUSID_ACCESS_TOKEN: ${{ secrets.DEVELOP_FBN_ACCESS_TOKEN }}
+      # but actually, we want to test what this is going to look like once it's been merged.
+      - name: Fork based /LGTM checkout
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ github.event.inputs.pull_request }}/merge"
+
+      # let the check run know it's in-progress; this shows up on the PR overview quite prominently
+      - name: Check Run in progress
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const date = new Date();
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: "${{ steps.vcs.outputs.sha }}",
+              name: "Integration Testing",
+
+              started_at: date.toISOString(),
+              external_id: "${{ github.run_id }}",
+              status: "in_progress",
+
+              output: {
+                title: "Integration Test Results",
+                summary: "Build started",
+                text: "Just gonna do stuff ya know."
+              }
+
+            });
+
+      - name: Run tests
+        id: run_tests
+        env:
+          FBN_LUSID_API_URL: ${{ secrets.URI }}
+          FBN_ACCESS_TOKEN: ${{ secrets.TOKEN }}
+          FBN_LUSID_ACCESS_TOKEN: ${{ secrets.TOKEN }}
         run: |
-          echo "env variables for DEVELOP have been set"
+          echo "env variables have been set"
           echo "Changing directory into sdk directory"
           cd sdk          
           echo "Running the tests..."
           docker-compose up --abort-on-container-exit
           echo "Tests COMPLETED"
-      
-      - name: Run tests on MASTER branch
-        if: ${{ github.base_ref == 'master' }}
-        env: 
-          FBN_TOKEN_URL: ${{ secrets.MASTER_FBN_TOKEN_URL }}
-          FBN_USERNAME: ${{ secrets.MASTER_FBN_USERNAME }}
-          FBN_PASSWORD: ${{ secrets.MASTER_FBN_PASSWORD }}
-          FBN_CLIENT_ID: ${{ secrets.MASTER_FBN_CLIENT_ID }}
-          FBN_CLIENT_SECRET: ${{ secrets.MASTER_FBN_CLIENT_SECRET }}
-          FBN_LUSID_API_URL: ${{ secrets.MASTER_FBN_LUSID_API_URL }}
-          FBN_APP_NAME: ${{ secrets.MASTER_FBN_CLIENT_ID }}
-          FBN_LUSID_ACCESS_TOKEN: ${{ secrets.MASTER_FBN_ACCESS_TOKEN }}
-        run: | 
-          echo "env variables for MASTER have been set"
-          echo "Changing directory into sdk directory"
-          cd sdk          
-          echo "Running the tests..."
-          docker-compose up --abort-on-container-exit
-          echo "Tests COMPLETED"
+
+      - name: Complete check run
+        if: always()
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const date = new Date();
+            const resp = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: "${{ github.run_id }}"
+            });
+
+            const URL = resp.data.jobs[0].html_url
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: "${{steps.vcs.outputs.sha}}",
+              name: "Integration Testing",
+
+              completed_at: date.toISOString(),
+
+              external_id: "${{ github.run_id }}",
+              details_url: resp.data.jobs[0].html_url,
+              status: "completed",
+              conclusion: "${{steps.run_tests.conclusion}}",
+
+              output: {
+                title: "Integration Tests",
+                summary: "Build completed with ${{steps.run_tests.conclusion}}",
+                text: `Visit the link to see the result of this step. ${URL}`
+              }
+            });
 
       - name: Slack notification
         uses: 8398a7/action-slack@v3
@@ -81,7 +123,7 @@ jobs:
             icon_emoji: ':octocat:',
             attachments: [{
               color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              text: `${process.env.AS_WORKFLOW} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.BRANCH_FOR_SLACK} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
+              text: `${process.env.AS_WORKFLOW} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@PR-${{ github.event.inputs.pull_request }} by ${process.env.GITHUB_ACTOR} failed in ${process.env.AS_TOOK}`
             }]
             }
         env:

--- a/all/generate/.github/workflows/cron.yaml
+++ b/all/generate/.github/workflows/cron.yaml
@@ -2,14 +2,14 @@ name: Daily build
 
 on:
   schedule:
-  - cron: "0 4 * * *"
+    - cron: "0 4 * * *"
 
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  cron-build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run tests on MASTER branch
         if: ${{ github.ref == 'refs/heads/master'}}
-        env: 
+        env:
           FBN_TOKEN_URL: ${{ secrets.MASTER_FBN_TOKEN_URL }}
           FBN_USERNAME: ${{ secrets.MASTER_FBN_USERNAME }}
           FBN_PASSWORD: ${{ secrets.MASTER_FBN_PASSWORD }}
@@ -26,15 +26,16 @@ jobs:
           FBN_CLIENT_SECRET: ${{ secrets.MASTER_FBN_CLIENT_SECRET }}
           FBN_LUSID_API_URL: ${{ secrets.MASTER_FBN_LUSID_API_URL }}
           FBN_APP_NAME: ${{ secrets.MASTER_FBN_CLIENT_ID }}
+          FBN_ACCESS_TOKEN: ${{ secrets.MASTER_FBN_ACCESS_TOKEN }}
           FBN_LUSID_ACCESS_TOKEN: ${{ secrets.MASTER_FBN_ACCESS_TOKEN }}
-        run: | 
+        run: |
           echo "env variables for MASTER have been set"
           echo "Changing directory into sdk directory"
           cd sdk          
           echo "Running the tests..."
           docker-compose up --abort-on-container-exit
           echo "Tests COMPLETED"
-    
+
       - name: Slack notification
         uses: 8398a7/action-slack@v3
         with:

--- a/all/generate/.github/workflows/notify-on-issue.yml
+++ b/all/generate/.github/workflows/notify-on-issue.yml
@@ -1,44 +1,44 @@
 name: Notifier
 
-on: [pull_request, issues]
+on: [pull_request_target, issues]
 
 jobs:
-  build:
+  notify-on-issue:
     runs-on: ubuntu-latest
     steps:
       - name: NotifyOpsGenie
         run: |
-              cat << EOF > contents.json
-              {
-                  "message": "${GITHUB_EVENT_NAME} raised against ${GITHUB_REPOSITORY}",
-                  "alias": "${GITHUB_REPOSITORY} requires attention",
-                  "description": "${GITHUB_EVENT_NAME} raised against ${GITHUB_REPOSITORY}",
-                  "details":
-                      {
-                          "CI": "$CI",
-                          "GITHUB_RUN_ID": "$GITHUB_RUN_ID",
-                          "GITHUB_RUN_NUMBER": "$GITHUB_RUN_NUMBER",
-                          "GITHUB_ACTION": "$GITHUB_ACTION",
-                          "GITHUB_ACTIONS": "$GITHUB_ACTIONS",
-                          "GITHUB_ACTOR": "$GITHUB_ACTOR",
-                          "GITHUB_REPOSITORY": "$GITHUB_REPOSITORY",
-                          "GITHUB_EVENT_NAME": "$GITHUB_EVENT_NAME",
-                          "GITHUB_WORKFLOW": "$GITHUB_WORKFLOW",
-                          "GITHUB_EVENT_PATH": "$GITHUB_EVENT_PATH",
-                          "GITHUB_WORKSPACE": "$GITHUB_WORKSPACE",
-                          "GITHUB_SHA": "$GITHUB_SHA",
-                          "GITHUB_REF": "$GITHUB_REF",
-                          "GITHUB_HEAD_REF": "$GITHUB_HEAD_REF",
-                          "GITHUB_BASE_REF": "$GITHUB_BASE_REF",
-                          "GITHUB_SERVER_URL": "$GITHUB_SERVER_URL",
-                          "GITHUB_API_URL": "$GITHUB_API_URL",
-                          "GITHUB_GRAPHQL_URL": "$GITHUB_GRAPHQL_URL"
-                      },
-                  "priority":"P2"
-              }
-              EOF
+          cat << EOF > contents.json
+          {
+              "message": "${GITHUB_EVENT_NAME} raised against ${GITHUB_REPOSITORY}",
+              "alias": "${GITHUB_REPOSITORY} requires attention",
+              "description": "${GITHUB_EVENT_NAME} raised against ${GITHUB_REPOSITORY}",
+              "details":
+                  {
+                      "CI": "$CI",
+                      "GITHUB_RUN_ID": "$GITHUB_RUN_ID",
+                      "GITHUB_RUN_NUMBER": "$GITHUB_RUN_NUMBER",
+                      "GITHUB_ACTION": "$GITHUB_ACTION",
+                      "GITHUB_ACTIONS": "$GITHUB_ACTIONS",
+                      "GITHUB_ACTOR": "$GITHUB_ACTOR",
+                      "GITHUB_REPOSITORY": "$GITHUB_REPOSITORY",
+                      "GITHUB_EVENT_NAME": "$GITHUB_EVENT_NAME",
+                      "GITHUB_WORKFLOW": "$GITHUB_WORKFLOW",
+                      "GITHUB_EVENT_PATH": "$GITHUB_EVENT_PATH",
+                      "GITHUB_WORKSPACE": "$GITHUB_WORKSPACE",
+                      "GITHUB_SHA": "$GITHUB_SHA",
+                      "GITHUB_REF": "$GITHUB_REF",
+                      "GITHUB_HEAD_REF": "$GITHUB_HEAD_REF",
+                      "GITHUB_BASE_REF": "$GITHUB_BASE_REF",
+                      "GITHUB_SERVER_URL": "$GITHUB_SERVER_URL",
+                      "GITHUB_API_URL": "$GITHUB_API_URL",
+                      "GITHUB_GRAPHQL_URL": "$GITHUB_GRAPHQL_URL"
+                  },
+              "priority":"P2"
+          }
+          EOF
 
-              curl -X POST https://api.opsgenie.com/v2/alerts \
-                  -H "Content-Type: application/json" \
-                  -H "Authorization: GenieKey ${{ secrets.OPSGENIE }}" \
-                  -d "@contents.json"
+          curl -X POST https://api.opsgenie.com/v2/alerts \
+              -H "Content-Type: application/json" \
+              -H "Authorization: GenieKey ${{ secrets.OPSGENIE }}" \
+              -d "@contents.json"

--- a/all/generate/.github/workflows/slack-on-issue.yaml
+++ b/all/generate/.github/workflows/slack-on-issue.yaml
@@ -7,14 +7,13 @@ on:
     types: [created, deleted, edited]
 
 jobs:
-
-  build:
+  slack-alert-on-issue:
     if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-          
+
       - name: Slack notification
         uses: 8398a7/action-slack@v3
         with:

--- a/all/generate/.github/workflows/slack-on-pr.yaml
+++ b/all/generate/.github/workflows/slack-on-pr.yaml
@@ -1,31 +1,29 @@
 name: Slack alert on PR
 
 on:
-  pull_request:
-    branches: [ master, develop ]
+  pull_request_target:
+    branches: [master, develop]
 
 jobs:
-
   slack-alert-on-pr:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 3
 
     steps:
-
-    - name: Slack notification on push
-      uses: 8398a7/action-slack@v3
-      with:
-        status: custom
-        fields: workflow,job,commit,repo,ref,author,took
-        custom_payload: |
-          {
-          username: 'github-actions',
-          icon_emoji: ':octocat:',
-          attachments: [{
-            color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-            text: `PR in ${process.env.AS_REPO} has been raised by ${process.env.GITHUB_ACTOR} (${process.env.GITHUB_HEAD_REF} into ${process.env.GITHUB_BASE_REF})`
-          }]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_FOR_GITHUB_ACTIVITY_CHANNEL }}
-      if: always()
+      - name: Slack notification on push
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,job,commit,repo,ref,author,took
+          custom_payload: |
+            {
+            username: 'github-actions',
+            icon_emoji: ':octocat:',
+            attachments: [{
+              color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              text: `PR in ${process.env.AS_REPO} has been raised by ${process.env.GITHUB_ACTOR} (${process.env.GITHUB_HEAD_REF} into ${process.env.GITHUB_BASE_REF})`
+            }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_FOR_GITHUB_ACTIVITY_CHANNEL }}
+        if: always()


### PR DESCRIPTION
This PR enables untrusted contributors to supply a fork based PR to the project.  Once reviewed by a trusted contributor (TC); that is a contributor who is a member of the organisation; the TC can comment on the PR with `/LGTM`, triggering a test run against a synthetic domain.

The mechanics of the trigger are fairly simple; an organisation level webhook fires to a webhook service that then triggers the workflow_dispatch resulting in the `build-and-test.yaml` action to fire, which creates a check_run so that the results of the testing are displayed prominently for all to see.

* `build-and-test-branches.yaml` now effectively only runs tests on a merge to the `develop` branch.
* `build-and-test.yaml` runs only for `workflow_dispatch` which is the sequence of events outlined above.
* `CODEOWNERS` is there as a placeholder.  I want that to be used for any PR's that change any of the workflows; they are after all, quite sensitive.
* Name changes for some of the jobs.
* Extended the timeout

Signed-off-by: Paul Saunders <pms1969@gmail.com>