### PR TITLE
CTECH-1344: Fixes references to non-existent paths for packages

### DIFF
--- a/python/generate/templates/__init__package.mustache
+++ b/python/generate/templates/__init__package.mustache
@@ -23,10 +23,10 @@ from {{packageName}}.exceptions import ApiException
 {{#models}}{{#model}}from {{modelPackage}}.{{classFilename}} import {{classname}}
 {{/model}}{{/models}}
 # import utilities into sdk package
-from {{packageName}}.utilities.api_client_builder import ApiClientBuilder
-from {{packageName}}.utilities.api_configuration import ApiConfiguration
-from {{packageName}}.utilities.api_configuration_loader import ApiConfigurationLoader
-from {{packageName}}.utilities.refreshing_token import RefreshingToken
+from fbnsdkutilities.utilities.api_client_builder import ApiClientBuilder
+from fbnsdkutilities.utilities.api_configuration import ApiConfiguration
+from fbnsdkutilities.utilities.api_configuration_loader import ApiConfigurationLoader
+from fbnsdkutilities.utilities.refreshing_token import RefreshingToken
 
 # import tcp utilities
-from {{packageName}}.tcp.tcp_keep_alive_probes import TCPKeepAlivePoolManager, TCPKeepAliveProxyManager
+from fbnsdkutilities.tcp.tcp_keep_alive_probes import TCPKeepAlivePoolManager, TCPKeepAliveProxyManager

--- a/python/generate/templates/rest.mustache
+++ b/python/generate/templates/rest.mustache
@@ -17,7 +17,7 @@ from six.moves.urllib.parse import urlencode
 import urllib3
 
 from {{packageName}}.exceptions import ApiException, ApiValueError
-from {{packageName}}.tcp.tcp_keep_alive_probes import TCPKeepAlivePoolManager, TCPKeepAliveProxyManager
+from fbnsdkutilities.tcp.tcp_keep_alive_probes import TCPKeepAlivePoolManager, TCPKeepAliveProxyManager
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>

When generating the luminesce package, we found references to utilities and tcp subpaths of the fbnsdkutilities package were referenced with the owning packages name.  This PR fixes the refs.