### PR TITLE
CTECH-1808: Allow plain text requests and responses from ApiClient

### DIFF
--- a/csharp/generate/templates/ApiClient.mustache
+++ b/csharp/generate/templates/ApiClient.mustache
@@ -355,25 +355,28 @@ namespace {{packageName}}.Client
                 }
                 else
                 {
-                    if (options.HeaderParameters != null)
+                    if (options.HeaderParameters != null && options.HeaderParameters.TryGetValue("Content-Type", out var contentTypes))
                     {
-                        var contentTypes = options.HeaderParameters["Content-Type"];
-                        if (contentTypes == null || contentTypes.Any(header => header.Contains("application/json")))
+                        // TODO: Generated client user should add additional handlers. RestSharp only supports XML and JSON, with XML as default.
+                        if (contentTypes.Any(header => header.Contains("application/json")))
                         {
-                            request.RequestFormat = DataFormat.Json;
+                            request.AddJsonBody(options.Data);
+                        }
+                        else if (contentTypes.Any(header => header.Contains("text/plain")))
+                        {
+                            request.RequestFormat = DataFormat.None;
+                            request.AddParameter("text/plain", options.Data, ParameterType.RequestBody);
                         }
                         else
                         {
-                            // TODO: Generated client user should add additional handlers. RestSharp only supports XML and JSON, with XML as default.
+                            request.AddJsonBody(options.Data);
                         }
                     }
                     else
                     {
                         // Here, we'll assume JSON APIs are more common. XML can be forced by adding produces/consumes to openapi spec explicitly.
-                        request.RequestFormat = DataFormat.Json;
+                        request.AddJsonBody(options.Data);
                     }
-
-                    request.AddJsonBody(options.Data);
                 }
             }
 

--- a/csharp/generate/templates/ApiClient.mustache
+++ b/csharp/generate/templates/ApiClient.mustache
@@ -498,13 +498,20 @@ namespace {{packageName}}.Client
                 var success = policyResult.Outcome == OutcomeType.Successful;
                 if (success)
                 {
-                    if ((policyResult.Result.ContentType.Equals("text/csv") ||
-                        policyResult.Result.ContentType.Equals("text/plain")) && typeof(T) == typeof(string))
+                    if (!string.IsNullOrEmpty(contentType))
                     {
-                        // no deserialisation needs to take place
-                        response = policyResult.Result.ToAsyncResponse<T>();
-                        // this is essentially converting a string to a string
-                        response.Data = (T) Convert.ChangeType(policyResult.Result.Content, typeof(T));
+                        if ((contentType.Equals("text/csv") || contentType.Equals("text/plain")) 
+                            && typeof(T) == typeof(string))
+                        {
+                            // no deserialisation needs to take place
+                            response = (IRestResponse<T>) policyResult.Result;
+                            // this is essentially converting a string to a string
+                            response.Data = (T) Convert.ChangeType(policyResult.Result.Content, typeof(T));
+                        }
+                        else
+                        {
+                            response = client.Deserialize<T>(policyResult.Result);
+                        }
                     }
                     else
                     {

--- a/csharp/generate/templates/ApiClient.mustache
+++ b/csharp/generate/templates/ApiClient.mustache
@@ -22,6 +22,7 @@ using Newtonsoft.Json.Serialization;
 using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
 using RestSharp;
 using RestSharp.Deserializers;
+using RestSharp.Extensions;
 using RestSharpMethod = RestSharp.Method;
 {{#useWebRequest}}
 using System.Net.Http;
@@ -494,11 +495,30 @@ namespace {{packageName}}.Client
             {
                 var policy = RetryConfiguration.RetryPolicy;
                 var policyResult = policy.ExecuteAndCapture(() => client.Execute(req));
-                response = (policyResult.Outcome == OutcomeType.Successful) ? client.Deserialize<T>(policyResult.Result) : new RestResponse<T>
+                var success = policyResult.Outcome == OutcomeType.Successful;
+                if (success)
                 {
-                    Request = req,
-                    ErrorException = policyResult.FinalException
-                };
+                    if ((policyResult.Result.ContentType.Equals("text/csv") ||
+                        policyResult.Result.ContentType.Equals("text/plain")) && typeof(T) == typeof(string))
+                    {
+                        // no deserialisation needs to take place
+                        response = policyResult.Result.ToAsyncResponse<T>();
+                        // this is essentially converting a string to a string
+                        response.Data = (T) Convert.ChangeType(policyResult.Result.Content, typeof(T));
+                    }
+                    else
+                    {
+                        response = client.Deserialize<T>(policyResult.Result);
+                    }
+                }
+                else
+                {
+                    response = new RestResponse<T>()
+                    {
+                        Request = req,
+                        ErrorException = policyResult.FinalException
+                    };
+                }
             }
             else
             {

--- a/csharp/generate/templates/ApiClient.mustache
+++ b/csharp/generate/templates/ApiClient.mustache
@@ -496,6 +496,7 @@ namespace {{packageName}}.Client
                 var policy = RetryConfiguration.RetryPolicy;
                 var policyResult = policy.ExecuteAndCapture(() => client.Execute(req));
                 var success = policyResult.Outcome == OutcomeType.Successful;
+                var contentType = policyResult.Result?.ContentType;
                 if (success)
                 {
                     if (!string.IsNullOrEmpty(contentType))


### PR DESCRIPTION
This fixes two issues with the ApiClient that present themselves in the Luminesce SDK.

The first issue is that we are unable to send a request body of type `text/plain`. This causes issues as there is a JSON encoded SQL query which luminesce cannot understand. 
To fix this issue, we check if the content type in `text/plain` and if so, we do not use the default JSON encoding. We state that there is no encoding, and add the plain text to the body.

The second issue was that when data was returned as `text/plain` or `text/csv`, we were not able to decode this. We assumed that the data was XML or JSON. 
To fix this, if the data returned is `text/plain` or `text/csv` AND the return type is simply a string, we now just convert the response into the correct type, and copy the string over to the data on this object.

All tests pass in the extensions, when referencing a locally built version of the luminesce SDK, where the ApiClient changes have been made
![image](https://user-images.githubusercontent.com/90201501/188915133-9ef108c3-e5d2-4ecf-a2ce-308433d35bf3.png)

Tests on the LUSID SDK also pass (the failure is due to lack of env vars):
![image](https://user-images.githubusercontent.com/90201501/189682166-fd44768a-85a7-471a-934e-702b7087feb1.png)

Tests on the C# examples repo also pass, with the Orders failures being unrelated, and under investigation.
![image](https://user-images.githubusercontent.com/90201501/189682468-a63985e1-f7dd-4005-94b0-3465d2041716.png)