### PR TITLE
CTECH-1811: Fixes the workflows so as to work with main or master as default branch

### DIFF
--- a/all/generate/.github/workflows/build-and-test-branches.yaml
+++ b/all/generate/.github/workflows/build-and-test-branches.yaml
@@ -3,7 +3,7 @@ name: Build and test develop branch
 # Trigger the workflow on merge to the develop branch
 on:
   push:
-    branches: [develop]
+    branches: [main, master, develop]
 
 jobs:
   # This workflow contains a single job called "build"

--- a/all/generate/.github/workflows/cron.yaml
+++ b/all/generate/.github/workflows/cron.yaml
@@ -16,8 +16,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Run tests on MASTER branch
-        if: ${{ github.ref == 'refs/heads/master'}}
+      - name: Run tests on the default branch
         env:
           FBN_TOKEN_URL: ${{ secrets.MASTER_FBN_TOKEN_URL }}
           FBN_USERNAME: ${{ secrets.MASTER_FBN_USERNAME }}

--- a/all/generate/.github/workflows/slack-on-pr.yaml
+++ b/all/generate/.github/workflows/slack-on-pr.yaml
@@ -2,7 +2,7 @@ name: Slack alert on PR
 
 on:
   pull_request_target:
-    branches: [master, develop]
+    branches: [main, master, develop]
 
 jobs:
   slack-alert-on-pr:


### PR DESCRIPTION
When creating a PR on the notifications sdk, discovered that the tests were not executing correctly against the main branch.  This is due to assumptions coded into the workflows in this repo.

Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>