### PR TITLE
CTECH-3046: Fixes timeout issue with client for long running requests

### DIFF
--- a/csharp/generate/templates/ApiClient.mustache
+++ b/csharp/generate/templates/ApiClient.mustache
@@ -253,6 +253,10 @@ namespace {{packageName}}.Client
             if (string.IsNullOrEmpty(basePath))
                 throw new ArgumentException("basePath cannot be empty");
 
+            // set some default servicepoint params.
+            ServicePointManager.SetTcpKeepAlive(true, 90_000, 90_000);
+            ServicePointManager.UseNagleAlgorithm = false;
+        
             _baseUrl = basePath;
         }
 

--- a/csharp/generate/templates/ApiClient.mustache
+++ b/csharp/generate/templates/ApiClient.mustache
@@ -236,6 +236,10 @@ namespace {{packageName}}.Client
         /// </summary>
         public ApiClient()
         {
+            // set some default servicepoint params.
+            ServicePointManager.SetTcpKeepAlive(true, 90_000, 90_000);
+            ServicePointManager.UseNagleAlgorithm = false;
+        
             _baseUrl = {{packageName}}.Client.GlobalConfiguration.Instance.BasePath;
         }
 
@@ -479,6 +483,11 @@ namespace {{packageName}}.Client
         private ApiResponse<T> Exec<T>(RestRequest req, IReadableConfiguration configuration)
         {
             RestClient client = new RestClient(_baseUrl);
+            client.ConfigureWebRequest(hwr =>
+            {
+                hwr.ServicePoint.UseNagleAlgorithm = false;
+                hwr.ServicePoint.SetTcpKeepAlive(true, 90_000, 90_000);
+            });
 
             client.ClearHandlers();
             var existingDeserializer = req.JsonSerializer as IDeserializer;
@@ -603,6 +612,11 @@ namespace {{packageName}}.Client
         private async Task<ApiResponse<T>> ExecAsync<T>(RestRequest req, IReadableConfiguration configuration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             RestClient client = new RestClient(_baseUrl);
+            client.ConfigureWebRequest(hwr =>
+            {
+                hwr.ServicePoint.UseNagleAlgorithm = false;
+                hwr.ServicePoint.SetTcpKeepAlive(true, 90_000, 90_000);
+            });
 
             client.ClearHandlers();
             var existingDeserializer = req.JsonSerializer as IDeserializer;
@@ -634,6 +648,7 @@ namespace {{packageName}}.Client
             client.AddHandler("*", () => xmlDeserializer);
 
             client.Timeout = configuration.Timeout;
+            client.ReadWriteTimeout = configuration.Timeout;
 
             if (configuration.Proxy != null)
             {

--- a/csharp/generate/templates/ApiClient.mustache
+++ b/csharp/generate/templates/ApiClient.mustache
@@ -510,6 +510,7 @@ namespace {{packageName}}.Client
             client.AddHandler("*", () => xmlDeserializer);
 
             client.Timeout = configuration.Timeout;
+            client.ReadWriteTimeout = configuration.Timeout;
 
             if (configuration.Proxy != null)
             {


### PR DESCRIPTION
As the title indicates, the change here ensures that the time to start writing the request back to the client is honoured.  

client.Timeout is the total time taken and remains set as before
client.ReadWriteTimeout is time to first bytes. This is new, and ensures that the client doesn't hang up after having not received a response.

We try and set the TCP Keepalive time and remove the use of the NagleAlgorithm, which buffers small packets (like TCP Keepalives).  I have witnessed zero effect from this config change on my Mac, but there is some chance it'll work on a windows machine; so I've left it in.

This has been tested with a locally build lusid-sdk; and shown to work. Without the added line, an exception was thrown 5m (300s) into a long running call.  With the added line, it certainly made it past that mark and subsequently could respond with a successful status code.