### PR TITLE
CTOOLS-736: Add ssh to the generator dockerfile

### DIFF
--- a/all/generate/Dockerfile
+++ b/all/generate/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.9.6-eclipse-temurin-11 as maven
 
-RUN apt-get update && apt-get -y install jq && apt-get -y install git
+RUN apt-get update && apt-get -y install jq git ssh
 
 RUN mkdir -p /usr/src/
 WORKDIR /usr/src/


### PR DESCRIPTION
Seems the image we updated to `maven:3.9.6-eclipse-temurin-11 as maven` is not built with ssh by default.  The sdk generation fails on this image with `bash: line 10: ssh-keyscan: command not found`.

This changes the dockerfile to install the ssh package to bring in ssh and ssh-keygen.