### PR TITLE
CTOOLS-817: Upgrading V1 sdk generation to fix error

### DIFF
--- a/all/generate/Dockerfile
+++ b/all/generate/Dockerfile
@@ -5,6 +5,6 @@ RUN apt-get update && apt-get -y install jq git ssh
 RUN mkdir -p /usr/src/
 WORKDIR /usr/src/
 
-RUN wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.1.0/openapi-generator-cli-5.1.0.jar -O openapi-generator-cli.jar
+RUN wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.4.0/openapi-generator-cli-5.4.0.jar -O openapi-generator-cli.jar
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
Bumping the sdk generator version from 5.1.0 -> 5.4.0 to resolve sdk generation error